### PR TITLE
Update to zig 0.15.0-dev.377+f01833e03

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.13.0
+          version: master
       - run: zig build release
       - name: zip artifact
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,8 @@ jobs:
       - uses: mlugg/setup-zig@v1
         with:
           version: master
-      - uses: leafo/gh-actions-lua@v10
+      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: leafo/gh-actions-lua@v11
         with:
           luaVersion: "5.4.7"
       - uses: luarocks/gh-actions-luarocks@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.13.0
+          version: master
       - uses: leafo/gh-actions-lua@v10
         with:
           luaVersion: "5.4.7"
@@ -29,5 +29,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.13.0
+          version: master
       - run: zig fmt --check .

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,9 +13,8 @@
             .hash = "libxev-0.0.0-86vtc-zkEgB7uv1i0Sa6ytJETZQi_lHJrImu9mLb9moi",
         },
         .zosc = .{
-            //.url = "git+https://github.com/robbielyman/zosc?ref=v1.1.0#ef8caf3c9f86b09b7fbed9fe6d4cdba3a43fb9de",
-            //.hash = "zosc-0.1.0-AAAAAMNlAQB8EI-CE0C8NRQRev0kus5li8OtBrecUdFE",
-            .path = "../zosc",
+            .url = "git+https://github.com/robbielyman/zosc?ref=main#574938ce59505e57df1ed7b22d505e84a4c6f051",
+            .hash = "zosc-0.1.0-Y0MRGIJmAQAp85zMQYfekmcK-CPy2U1bNAN3H0-gH3XS",
         },
         .embed_file = .{
             .url = "git+https://github.com/robbielyman/EmbedFile.zig?ref=main#67d95b1a7db29bf80fe7db5daeb3878b1002f3e9",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,27 +1,29 @@
 .{
-    .name = "seamstress",
+    .name = .steamstress,
     .version = "2.0.0-prealpha-3",
+    .fingerprint = 0xd0e1bb1829aedf14,
     .paths = .{ "build.zig.zon", "build.zig", "src", "lua" },
     .dependencies = .{
-        .ziglua = .{
-            .url = "git+https://github.com/robbielyman/ziglua?ref=byo-lua#69a86667f31257e8529a3d20e1799283984bead5",
-            .hash = "12202e945f7d80689f48333beefd8a1993f3a67ca6af400d9c746f1a121fc7cb78fa",
+        .zlua = .{
+            .url = "git+https://github.com/natecraddock/ziglua?ref=main#dfa5b912efe4eaf17e3ae8317b2966ddaa457de6",
+            .hash = "zlua-0.1.0-hGRpC7QOBQBY97K-rliWJXOgrVvFmY9hPTQ5fOsvqDKa",
         },
         .libxev = .{
-            .url = "git+https://github.com/robbielyman/libxev?ref=seamstress-branch#8cfc85b21974996775d7ca8a4febc5d0963e6f7f",
-            .hash = "1220c9e5ef90baa4bcc9ceb73edf54961ca4de5d0bcebec6aff38a20079947b04682",
+            .url = "git+https://github.com/mitchellh/libxev?ref=main#94ed6af7b2aaaeab987fbf87fcee410063df715b",
+            .hash = "libxev-0.0.0-86vtc-zkEgB7uv1i0Sa6ytJETZQi_lHJrImu9mLb9moi",
         },
         .zosc = .{
-            .url = "git+https://github.com/robbielyman/zosc?ref=v1.1.0#ef8caf3c9f86b09b7fbed9fe6d4cdba3a43fb9de",
-            .hash = "12207c108f821340bc3514117afd24bace658bc3ad06b79c51d1440eb498cec4349c",
+            //.url = "git+https://github.com/robbielyman/zosc?ref=v1.1.0#ef8caf3c9f86b09b7fbed9fe6d4cdba3a43fb9de",
+            //.hash = "zosc-0.1.0-AAAAAMNlAQB8EI-CE0C8NRQRev0kus5li8OtBrecUdFE",
+            .path = "../zosc",
         },
-        .@"embed-file" = .{
-            .url = "git+https://github.com/robbielyman/EmbedFile.zig#b5ae28c2812a510de762b41cea489aad80bc039a",
-            .hash = "1220633202df3bfbf2436d80dee0cf94b7eeab59177b4d777680f175a08fa8deaf41",
+        .embed_file = .{
+            .url = "git+https://github.com/robbielyman/EmbedFile.zig?ref=main#67d95b1a7db29bf80fe7db5daeb3878b1002f3e9",
+            .hash = "embed_file-1.0.0-xHnAJbRyAACyaZoX76xXnqJr8ZPsACm12-D4C_VIXEFc",
         },
-        .@"known-folders" = .{
-            .url = "git+https://github.com/ziglibs/known-folders#1cceeb70e77dec941a4178160ff6c8d05a74de6f",
-            .hash = "12205f5e7505c96573f6fc5144592ec38942fb0a326d692f9cddc0c7dd38f9028f29",
+        .known_folders = .{
+            .url = "git+https://github.com/ziglibs/known-folders?ref=master#aa24df42183ad415d10bc0a33e6238c437fc0f59",
+            .hash = "known_folders-0.0.0-Fy-PJtLDAADGDOwYwMkVydMSTp_aN-nfjCZw6qPQ2ECL",
         },
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .paths = .{ "build.zig.zon", "build.zig", "src", "lua" },
     .dependencies = .{
         .zlua = .{
-            .url = "git+https://github.com/natecraddock/ziglua?ref=main#dfa5b912efe4eaf17e3ae8317b2966ddaa457de6",
-            .hash = "zlua-0.1.0-hGRpC7QOBQBY97K-rliWJXOgrVvFmY9hPTQ5fOsvqDKa",
+            .url = "git+https://github.com/natecraddock/ziglua#f7b3c90d026afd33b0a70debfd54ea50f1acfc1b",
+            .hash = "zlua-0.1.0-hGRpC-IZBQDD9MfKTbeRE3z_Qg-kI2SqnT1JaRl9W9Sq",
         },
         .libxev = .{
             .url = "git+https://github.com/mitchellh/libxev?ref=main#94ed6af7b2aaaeab987fbf87fcee410063df715b",

--- a/design.org
+++ b/design.org
@@ -250,7 +250,7 @@ Here is an example from =cli.zig=:
   // l is the seamstress Lua environment.
   // self is a pointer to the CLI struct
   l.pushLightUserdata(self);
-  l.pushClosure(ziglua.wrap(struct {
+  l.pushClosure(zlua.wrap(struct {
       fn f(l: *Lua) i32 {
           const i = Lua.upvalueIndex(1);
           const cli = l.toUserdata(Cli, i) catch unreachable;

--- a/src/args.zig
+++ b/src/args.zig
@@ -1,10 +1,10 @@
 const Args = @This();
 
-logging: logging.Args,
+log: logging.Args,
 run: Seamstress.RunArgs,
 
 pub fn format(args: Args, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
-    try writer.print("log file: {s}, log level: {s}\n", .{ args.logging.path orelse "default", switch (args.logging.level) {
+    try writer.print("log file: {s}, log level: {s}\n", .{ args.log.path orelse "default", switch (args.log.level) {
         .err => "error",
         .warn => "warning",
         .info => "info",
@@ -67,7 +67,7 @@ pub fn process(cli_args: []const []const u8) Args {
         file = arg;
     }
     return .{
-        .logging = logging_arg,
+        .log = logging_arg,
         .run = .{
             .file = file,
             .tests = .{

--- a/src/cli/stdin.zig
+++ b/src/cli/stdin.zig
@@ -20,6 +20,7 @@ const S = xev.stream.Stream(xev, @This(), .{
     .write = .none,
     .close = false,
     .threadpool = false,
+    .poll = true,
 });
 
 pub const ReadError = S.ReadError;

--- a/src/config.zig
+++ b/src/config.zig
@@ -2,7 +2,7 @@
 pub fn configure(seamstress: *Seamstress) void {
     const l = seamstress.l;
     defer if (interpolated) |str| seamstress.allocator.free(str);
-    l.load(ziglua.wrap(loader), seamstress, "=configure", .text) catch {
+    l.load(zlua.wrap(loader), seamstress, "=configure", .text) catch {
         const err = l.toStringEx(-1);
         panic("{s}", .{err});
     };
@@ -37,8 +37,8 @@ const std = @import("std");
 const Seamstress = @import("seamstress.zig");
 const panic = std.debug.panic;
 const lu = @import("lua_util.zig");
-const ziglua = @import("ziglua");
-const Lua = ziglua.Lua;
+const zlua = @import("zlua");
+const Lua = zlua.Lua;
 
 const script =
     \\return function()

--- a/src/logging.zig
+++ b/src/logging.zig
@@ -110,7 +110,7 @@ var log_level: std.log.Level = switch (builtin.mode) {
 
 pub fn logFn(
     comptime level: std.log.Level,
-    comptime scope: @Type(.EnumLiteral),
+    comptime scope: @Type(.enum_literal),
     comptime fmt: []const u8,
     args: anytype,
 ) void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -58,7 +58,7 @@ fn setAbrtHandler() !void {
                 }
             }.handleAbrt,
         },
-        .mask = if (builtin.os.tag == .linux) std.posix.empty_sigset else 0,
+        .mask = if (builtin.os.tag == .linux) std.posix.sigemptyset() else 0,
         .flags = 0,
     };
     std.posix.sigaction(std.posix.SIG.ABRT, &act, null);

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,7 +9,7 @@ pub fn main() !void {
     const cli_args = try std.process.argsAlloc(allocator);
     const args = Args.process(cli_args);
 
-    logging.init(allocator, args.logging);
+    logging.init(allocator, args.log);
 
     std.log.scoped(.args).debug("{}", .{args});
 
@@ -30,8 +30,8 @@ pub fn main() !void {
     const using_sigaction = builtin.mode == .Debug and builtin.os.tag != .windows;
     if (using_sigaction) setAbrtHandler() catch {};
 
-    const l = try Lua.init(&allocator);
-    defer l.close();
+    const l = try Lua.init(allocator);
+    defer l.deinit();
 
     panic_closure = .{
         .ctx = l,
@@ -61,7 +61,7 @@ fn setAbrtHandler() !void {
         .mask = if (builtin.os.tag == .linux) std.posix.empty_sigset else 0,
         .flags = 0,
     };
-    try std.posix.sigaction(std.posix.SIG.ABRT, &act, null);
+    std.posix.sigaction(std.posix.SIG.ABRT, &act, null);
 }
 
 pub const known_folders_config = logging.known_folders_config;
@@ -87,14 +87,15 @@ pub fn panic(msg: []const u8, error_return_trace: ?*std.builtin.StackTrace, ret_
         p.panic_fn(p.ctx);
     }
     // inline so that stack traces are correct
-    @call(.always_inline, std.builtin.default_panic, .{ msg, error_return_trace, ret_addr });
+    if (error_return_trace) |trace| std.debug.dumpStackTrace(trace.*);
+    @call(.always_inline, std.debug.defaultPanic, .{ msg, ret_addr });
 }
 
 const std = @import("std");
 const builtin = @import("builtin");
 const Seamstress = @import("seamstress.zig");
-const ziglua = @import("ziglua");
-const Lua = ziglua.Lua;
+const zlua = @import("zlua");
+const Lua = zlua.Lua;
 const lu = @import("lua_util.zig");
 const logging = @import("logging.zig");
 const Args = @import("args.zig");

--- a/src/modules.zig
+++ b/src/modules.zig
@@ -1,22 +1,22 @@
 /// the master list of all seamstress modules
 /// pub so that the loader function defined in seamstress.zig can access it
-pub const list = std.StaticStringMap(*const fn (?*ziglua.LuaState) callconv(.C) i32).initComptime(.{
-    .{ "seamstress", ziglua.wrap(@import("seamstress.zig").register) },
-    .{ "seamstress.event", ziglua.wrap(openFn("event.lua")) },
-    .{ "seamstress.async", ziglua.wrap(@import("async.zig").register(.@"async")) },
-    .{ "seamstress.async.Promise", ziglua.wrap(@import("async.zig").register(.promise)) },
-    .{ "seamstress.test", ziglua.wrap(openFn("test.lua")) },
-    .{ "seamstress.Timer", ziglua.wrap(@import("timer.zig").register) },
-    .{ "seamstress.osc", ziglua.wrap(@import("osc.zig").register(.osc)) },
-    .{ "seamstress.osc.Client", ziglua.wrap(@import("osc.zig").register(.client)) },
-    .{ "seamstress.osc.Server", ziglua.wrap(@import("osc.zig").register(.server)) },
-    .{ "seamstress.osc.Message", ziglua.wrap(@import("osc.zig").register(.message)) },
-    .{ "seamstress.monome", ziglua.wrap(@import("monome.zig").register(.monome)) },
-    .{ "seamstress.monome.Grid", ziglua.wrap(@import("monome.zig").register(.grid)) },
-    .{ "seamstress.monome.Arc", ziglua.wrap(@import("monome.zig").register(.arc)) },
-    .{ "seamstress.repl", ziglua.wrap(@import("repl.zig").register) },
-    .{ "seamstress.cli", ziglua.wrap(@import("cli.zig").register) },
-    .{ "seamstress.builtin_test_files", ziglua.wrap(builtinTestFiles) },
+pub const list = std.StaticStringMap(*const fn (?*zlua.LuaState) callconv(.C) i32).initComptime(.{
+    .{ "seamstress", zlua.wrap(@import("seamstress.zig").register) },
+    .{ "seamstress.event", zlua.wrap(openFn("event.lua")) },
+    .{ "seamstress.async", zlua.wrap(@import("async.zig").register(.@"async")) },
+    .{ "seamstress.async.Promise", zlua.wrap(@import("async.zig").register(.promise)) },
+    .{ "seamstress.test", zlua.wrap(openFn("test.lua")) },
+    .{ "seamstress.Timer", zlua.wrap(@import("timer.zig").register) },
+    .{ "seamstress.osc", zlua.wrap(@import("osc.zig").register(.osc)) },
+    .{ "seamstress.osc.Client", zlua.wrap(@import("osc.zig").register(.client)) },
+    .{ "seamstress.osc.Server", zlua.wrap(@import("osc.zig").register(.server)) },
+    .{ "seamstress.osc.Message", zlua.wrap(@import("osc.zig").register(.message)) },
+    .{ "seamstress.monome", zlua.wrap(@import("monome.zig").register(.monome)) },
+    .{ "seamstress.monome.Grid", zlua.wrap(@import("monome.zig").register(.grid)) },
+    .{ "seamstress.monome.Arc", zlua.wrap(@import("monome.zig").register(.arc)) },
+    .{ "seamstress.repl", zlua.wrap(@import("repl.zig").register) },
+    .{ "seamstress.cli", zlua.wrap(@import("cli.zig").register) },
+    .{ "seamstress.builtin_test_files", zlua.wrap(builtinTestFiles) },
 });
 
 fn openFn(comptime filename: []const u8) fn (*Lua) i32 {
@@ -55,7 +55,7 @@ fn loadComptime(l: *Lua, comptime module_name: [:0]const u8) void {
 fn builtinTestFiles(l: *Lua) i32 {
     const decls = comptime std.meta.declarations(assets.@"test");
     l.createTable(decls.len, 0);
-    var idx: ziglua.Integer = 1;
+    var idx: zlua.Integer = 1;
     inline for (decls) |decl| {
         _ = l.pushAny(.{
             .filename = decl.name,
@@ -71,6 +71,6 @@ const assets = @import("assets");
 
 const std = @import("std");
 const builtin = @import("builtin");
-const ziglua = @import("ziglua");
-const Lua = ziglua.Lua;
+const zlua = @import("zlua");
+const Lua = zlua.Lua;
 const lu = @import("lua_util.zig");

--- a/src/monome.zig
+++ b/src/monome.zig
@@ -27,7 +27,7 @@ pub fn register(comptime which: enum { monome, grid, arc }) fn (*Lua) i32 {
                         return 1;
                     }
                 }.f;
-                l.pushClosure(ziglua.wrap(realLoader), 2);
+                l.pushClosure(zlua.wrap(realLoader), 2);
                 return 1;
             }
         }.f,
@@ -124,7 +124,7 @@ fn @"/serialosc/device"(l: *Lua, from: std.net.Address, path: []const u8, id: []
     }
     lu.preparePublish(l, if (is_arc) &.{ "monome", "arc", "add" } else &.{ "monome", "grid", "add" });
     l.rotate(-3, -1); // publish, namespace, device
-    l.call(2, 0); // publish(namespace, device)
+    l.call(.{ .args = 2 }); // publish(namespace, device)
     return .no;
 }
 
@@ -152,7 +152,7 @@ fn @"/serialosc/remove"(l: *Lua, from: std.net.Address, _: []const u8, id: []con
     lu.preparePublish(l, if (is_arc) &.{ "monome", "arc", "remove" } else &.{ "monome", "grid", "remove" });
     _ = l.pushString(id);
     l.pushInteger(port);
-    l.call(3, 0);
+    l.call(.{ .args = 3 });
     return .no;
 }
 
@@ -169,8 +169,8 @@ fn @"/serialosc/notify"(l: *Lua, to: std.net.Address) void {
     };
 }
 
-const ziglua = @import("ziglua");
-const Lua = ziglua.Lua;
+const zlua = @import("zlua");
+const Lua = zlua.Lua;
 const osc = @import("osc.zig");
 const lu = @import("lua_util.zig");
 const z = osc.z;

--- a/src/monome/arc.zig
+++ b/src/monome/arc.zig
@@ -1,24 +1,24 @@
 pub fn register(l: *Lua) i32 {
     blk: {
         l.newMetatable("seamstress.monome.Arc") catch break :blk;
-        const funcs: []const ziglua.FnReg = &.{
-            .{ .name = "__index", .func = ziglua.wrap(common.__index(.arc)) },
-            .{ .name = "__newindex", .func = ziglua.wrap(common.__newindex(.arc)) },
-            .{ .name = "__gc", .func = ziglua.wrap(common.__gc(.arc)) },
-            .{ .name = "refresh", .func = ziglua.wrap(refresh) },
-            .{ .name = "led", .func = ziglua.wrap(led) },
-            .{ .name = "all", .func = ziglua.wrap(all) },
-            .{ .name = "connect", .func = ziglua.wrap(common.connect(.arc)) },
-            .{ .name = "info", .func = ziglua.wrap(common.@"/sys/info") },
+        const funcs: []const zlua.FnReg = &.{
+            .{ .name = "__index", .func = zlua.wrap(common.__index(.arc)) },
+            .{ .name = "__newindex", .func = zlua.wrap(common.__newindex(.arc)) },
+            .{ .name = "__gc", .func = zlua.wrap(common.__gc(.arc)) },
+            .{ .name = "refresh", .func = zlua.wrap(refresh) },
+            .{ .name = "led", .func = zlua.wrap(led) },
+            .{ .name = "all", .func = zlua.wrap(all) },
+            .{ .name = "connect", .func = zlua.wrap(common.connect(.arc)) },
+            .{ .name = "info", .func = zlua.wrap(common.@"/sys/info") },
         };
         l.setFuncs(funcs, 0);
     }
     l.pop(1);
     l.newTable();
     l.newTable();
-    const funcs: []const ziglua.FnReg = &.{
-        .{ .name = "__call", .func = ziglua.wrap(__call) },
-        .{ .name = "connect", .func = ziglua.wrap(connect) },
+    const funcs: []const zlua.FnReg = &.{
+        .{ .name = "__call", .func = zlua.wrap(__call) },
+        .{ .name = "connect", .func = zlua.wrap(connect) },
     };
     l.setFuncs(funcs, 0);
     _ = l.pushStringZ("__index");
@@ -66,7 +66,7 @@ fn connect(l: *Lua) i32 {
     // g:connect()
     _ = l.getMetaField(-1, "connect") catch unreachable;
     l.pushValue(-2);
-    l.call(1, 0);
+    l.call(.{ .args = 1 });
     return 1; // return g
 }
 
@@ -120,7 +120,7 @@ fn all(l: *Lua) i32 {
     const arc = l.checkUserdata(Arc, 1, "seamstress.monome.Arc");
     const level = common.checkIntegerAcceptingNumber(l, 2);
     l.argCheck(0 <= level and level <= 15, 2, "level must be between 0 and 15!");
-    var i: ziglua.Integer = 1;
+    var i: zlua.Integer = 1;
     blk: {
         if ((l.getUserValue(1, 2) catch unreachable) == .nil) break :blk;
         while (i <= 4) : (i += 1) {
@@ -149,7 +149,7 @@ pub const Decls = struct {
         if (!lu.isCallable(l, -1)) return .yes;
         l.pushInteger(n + 1);
         l.pushInteger(d);
-        l.call(2, 0);
+        l.call(.{ .args = 2 });
         return .no;
     }
 
@@ -159,7 +159,7 @@ pub const Decls = struct {
         if (!lu.isCallable(l, -1)) return .yes;
         l.pushInteger(n + 1);
         l.pushInteger(z);
-        l.call(2, 0);
+        l.call(.{ .args = 2 });
         return .no;
     }
 };
@@ -172,8 +172,8 @@ pub const DeclsTypes = std.StaticStringMap([]const u8).initComptime(.{
     .{ "//enc/key", "ii" },
 });
 
-const ziglua = @import("ziglua");
-const Lua = ziglua.Lua;
+const zlua = @import("zlua");
+const Lua = zlua.Lua;
 const osc = @import("../osc.zig");
 const lu = @import("../lua_util.zig");
 const common = @import("common.zig");

--- a/src/osc.zig
+++ b/src/osc.zig
@@ -23,7 +23,7 @@ pub fn pushAddress(l: *Lua, comptime mode: enum { array, table, string }, addr: 
     var counter = std.io.countingWriter(std.io.null_writer);
     addr.format("", .{}, counter.writer()) catch unreachable;
     const size: usize = @intCast(counter.bytes_written);
-    var buf: ziglua.Buffer = undefined;
+    var buf: zlua.Buffer = undefined;
     const slice = buf.initSize(l, @intCast(size));
     var fbs = std.io.fixedBufferStream(slice);
     addr.format("", .{}, fbs.writer()) catch unreachable;
@@ -31,7 +31,7 @@ pub fn pushAddress(l: *Lua, comptime mode: enum { array, table, string }, addr: 
         .string => buf.pushResultSize(@intCast(size)),
         .array, .table => {
             const colon_idx = std.mem.indexOfScalar(u8, slice, ':').?;
-            const port = std.fmt.parseInt(ziglua.Integer, slice[colon_idx + 1 .. size], 10) catch unreachable;
+            const port = std.fmt.parseInt(zlua.Integer, slice[colon_idx + 1 .. size], 10) catch unreachable;
             buf.pushResultSize(colon_idx);
             l.createTable(2, 0);
             l.rotate(-2, 1);
@@ -144,7 +144,7 @@ pub fn wrap(l: *Lua, comptime arg_types: []const u8, zigFn: anytype, num_upvalue
             return 1;
         }
     }.wrapped;
-    l.pushClosure(ziglua.wrap(wrapped), num_upvalues);
+    l.pushClosure(zlua.wrap(wrapped), num_upvalues);
     l.newTable();
     l.createTable(0, 3);
     l.rotate(-3, -1);
@@ -184,7 +184,7 @@ pub fn pushData(l: *Lua, data: z.Data) void {
         .i, .h => |i| l.pushInteger(i),
         .f, .d => |f| l.pushNumber(f),
         .r => |r| {
-            var buf: ziglua.Buffer = undefined;
+            var buf: zlua.Buffer = undefined;
             const slice = buf.initSize(l, 9);
             _ = std.fmt.bufPrint(slice, "#{x}", .{r}) catch unreachable;
             buf.pushResultSize(9);
@@ -280,8 +280,8 @@ pub fn toData(l: *Lua, tag: ?u8) !z.Data {
 pub const Server = @import("osc/server.zig");
 pub const Client = @import("osc/client.zig");
 pub const z = @import("zosc");
-const ziglua = @import("ziglua");
-const Lua = ziglua.Lua;
+const zlua = @import("zlua");
+const Lua = zlua.Lua;
 const lu = @import("lua_util.zig");
 const xev = @import("xev");
 const std = @import("std");

--- a/src/osc/message.zig
+++ b/src/osc/message.zig
@@ -1,14 +1,14 @@
 pub fn register(l: *Lua) i32 {
     blk: {
         l.newMetatable("seamstress.osc.Message") catch break :blk; // new metatable
-        const funcs: []const ziglua.FnReg = &.{
-            .{ .name = "__index", .func = ziglua.wrap(__index) },
-            .{ .name = "__newindex", .func = ziglua.wrap(__newindex) },
-            .{ .name = "__gc", .func = ziglua.wrap(__gc) },
-            .{ .name = "bytes", .func = ziglua.wrap(bytes) },
-            .{ .name = "__eq", .func = ziglua.wrap(__eq) },
-            .{ .name = "__ipairs", .func = ziglua.wrap(__ipairs) },
-            .{ .name = "__len", .func = ziglua.wrap(__len) },
+        const funcs: []const zlua.FnReg = &.{
+            .{ .name = "__index", .func = zlua.wrap(__index) },
+            .{ .name = "__newindex", .func = zlua.wrap(__newindex) },
+            .{ .name = "__gc", .func = zlua.wrap(__gc) },
+            .{ .name = "bytes", .func = zlua.wrap(bytes) },
+            .{ .name = "__eq", .func = zlua.wrap(__eq) },
+            .{ .name = "__ipairs", .func = zlua.wrap(__ipairs) },
+            .{ .name = "__len", .func = zlua.wrap(__len) },
         };
         l.setFuncs(funcs, 0);
         // _ = l.pushString("seamstress.osc.Message");
@@ -16,7 +16,7 @@ pub fn register(l: *Lua) i32 {
         // l.setTable(-3);
     }
     l.pop(1);
-    l.pushFunction(ziglua.wrap(new));
+    l.pushFunction(zlua.wrap(new));
     return 1;
 }
 
@@ -29,7 +29,7 @@ fn __index(l: *Lua) i32 {
         return 1;
     }
     if (l.compare(2, -1, .eq)) { // k == "types"
-        var buf: ziglua.Buffer = undefined;
+        var buf: zlua.Buffer = undefined;
         _ = buf.initSize(l, builder.data.items.len);
         for (builder.data.items) |data|
             buf.addChar(@tagName(data)[0]);
@@ -47,7 +47,7 @@ fn __index(l: *Lua) i32 {
         else => l.argError(2, "integer expected"),
     }
     const idx = l.toInteger(2) catch unreachable;
-    if (idx <= 0 or idx > std.math.cast(ziglua.Integer, builder.data.items.len) orelse 0)
+    if (idx <= 0 or idx > std.math.cast(zlua.Integer, builder.data.items.len) orelse 0)
         return 0; // nothing at that index!
     osc.pushData(l, builder.data.items[@intCast(idx - 1)]); // push the data
     return 1;
@@ -140,7 +140,7 @@ fn __ipairs(l: *Lua) i32 {
         }
     }.f;
     // return iterator, msg, 1
-    l.pushFunction(ziglua.wrap(iteratorFn));
+    l.pushFunction(zlua.wrap(iteratorFn));
     l.pushValue(1);
     l.pushInteger(1);
     return 3;
@@ -181,7 +181,7 @@ fn new(l: *Lua) i32 {
         const types: ?[]const u8 = if (l.getField(1, "types") == .string) l.toString(-1) catch unreachable else null;
         l.pop(1);
         if (types) |string| {
-            var idx: ziglua.Integer = 1; // traverse the array part of the table
+            var idx: zlua.Integer = 1; // traverse the array part of the table
             for (string) |tag| { // using the typetag as the source of truth
                 _ = l.getIndex(1, idx);
                 defer l.pop(1);
@@ -199,7 +199,7 @@ fn new(l: *Lua) i32 {
             l.len(1); // get the length
             const len = l.toInteger(-1) catch unreachable;
             l.pop(1);
-            var idx: ziglua.Integer = 1; // traverse the array part of the table
+            var idx: zlua.Integer = 1; // traverse the array part of the table
             while (idx <= len) : (idx += 1) {
                 _ = l.getIndex(1, idx);
                 defer l.pop(1);
@@ -229,6 +229,6 @@ fn pullIn(l: *Lua, builder: *z.Message.Builder, tag: ?u8) !void {
 const z = @import("zosc");
 const osc = @import("../osc.zig");
 const std = @import("std");
-const ziglua = @import("ziglua");
-const Lua = ziglua.Lua;
+const zlua = @import("zlua");
+const Lua = zlua.Lua;
 const lu = @import("../lua_util.zig");

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -1,5 +1,5 @@
 pub fn register(l: *Lua) i32 {
-    l.pushFunction(ziglua.wrap(repl));
+    l.pushFunction(zlua.wrap(repl));
     return 1;
 }
 
@@ -23,14 +23,14 @@ fn processChunk(l: *Lua, buffer: []const u8) !enum { ok, incomplete } {
     l.loadBuffer(with_return, "=repl", .text) catch |err| {
         // ... if the chunk does not compile
         switch (err) {
-            error.Memory => return error.OutOfMemory,
-            error.Syntax => {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.LuaSyntax => {
                 // remove the error message
                 l.pop(1);
                 // load the original buffer
                 l.loadBuffer(buffer, "=repl", .text) catch |err2| switch (err2) {
-                    error.Memory => return error.OutOfMemory,
-                    error.Syntax => {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    error.LuaSyntax => {
                         const msg = l.toStringEx(-1);
                         // does the syntax error tell us the statement isn't finished?
                         if (std.mem.endsWith(u8, msg, "<eof>")) {
@@ -51,7 +51,7 @@ fn processChunk(l: *Lua, buffer: []const u8) !enum { ok, incomplete } {
     return .ok;
 }
 
-const ziglua = @import("ziglua");
-const Lua = ziglua.Lua;
+const zlua = @import("zlua");
+const Lua = zlua.Lua;
 const lu = @import("lua_util.zig");
 const std = @import("std");

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,9 +1,9 @@
-export fn luaopen_seamstress(l: ?*ziglua.LuaState) c_int {
+export fn luaopen_seamstress(l: ?*zlua.LuaState) c_int {
     const lua: *Lua = @ptrCast(l.?);
     return @call(.always_inline, Seamstress.register, .{lua});
 }
 
 const Seamstress = @import("seamstress.zig");
 const std = @import("std");
-const ziglua = @import("ziglua");
-const Lua = ziglua.Lua;
+const zlua = @import("zlua");
+const Lua = zlua.Lua;


### PR DESCRIPTION
Hello! I was intrigued by seamstress and decided to try to run it on my machine. This PR is the product of me updating it to run on the latest Zig branch.

There are some updates to dependency versions, some refactoring due to ziglua, Zig builtins (`@branchHint`), Zig build system, and libxev API changes.

For the dependencies, I had to update them to conform with the new build.zig.zon structure:

- ziglua: I updated ziglua to the tip of the current main branch, while previously it was pointing at a branch on your fork (robbielyman/ziglua#byo-lua)
- libxev: I updated libxev to the tip of the current main branch, while previously it was pointing at a branch on your fork (robbielyman/libxev#seamstress-branch)
- zosc: Required some updates itself, which are in a PR (see https://github.com/robbielyman/zosc/pull/1). Once that's merged, the dependency reference needs to be updated again. (This is the reason this PR is in draft mode.)
- embed_file: Updated to the latest main
- known_folders: Updated to the latest main

---

Side note: I got it to run and it drops me into a Lua repl, but I'm not sure what else to do from here! I did find [Grid Studies](https://monome.org/docs/grid/studies/seamstress/), but I don't own a Monome Grid. Is this only suitable for users who own a Monome Grid, or is it capable of working with OSC/midi with programs on the user's machine as well? I'd be excited to play around with this given more docs/guidance, or if there are features you're planning on implementing related to software synths I would also be willing to contribute some code.